### PR TITLE
fix(alerts): do not fire KubePdbNotEnoughHealthyPods when a PDB selects no pods

### DIFF
--- a/alerts/apps_alerts.libsonnet
+++ b/alerts/apps_alerts.libsonnet
@@ -398,6 +398,9 @@ local utils = import '../lib/utils.libsonnet';
                 kube_poddisruptionbudget_status_current_healthy{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
               )
               > 0
+              and
+              kube_poddisruptionbudget_status_expected_pods{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s}
+              > 0
             ||| % $._config,
             labels: {
               severity: 'warning',

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -24,6 +24,8 @@ tests:
     values: '4x15'
   - series: 'kube_poddisruptionbudget_status_current_healthy{cluster="cluster1", namespace="ns1", poddisruptionbudget="pdb1", job="kube-state-metrics"}'
     values: '3x15'
+  - series: 'kube_poddisruptionbudget_status_expected_pods{cluster="cluster1", namespace="ns1", poddisruptionbudget="pdb1", job="kube-state-metrics"}'
+    values: '4x15'
   alert_rule_test:
   - eval_time: 14m
     alertname: KubePdbNotEnoughHealthyPods
@@ -40,6 +42,23 @@ tests:
         description: "PDB ns1/pdb1 expects 1 more healthy pods. The desired number of healthy pods has not been met for at least 15m."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepdbnotenoughhealthypods"
         summary: "PDB does not have enough healthy pods."
+
+- interval: 1m
+  name: KubePdbNotEnoughHealthyPods does not fire when the PDB selects no pods
+  input_series:
+  # A PDB with an absolute minAvailable reports desiredHealthy from the spec even when its
+  # selector matches nothing, so a workload scaled to zero replicas shows a permanent deficit.
+  - series: 'kube_poddisruptionbudget_status_desired_healthy{cluster="cluster1", namespace="ns1", poddisruptionbudget="pdb1", job="kube-state-metrics"}'
+    values: '1x30'
+  - series: 'kube_poddisruptionbudget_status_current_healthy{cluster="cluster1", namespace="ns1", poddisruptionbudget="pdb1", job="kube-state-metrics"}'
+    values: '0x30'
+  - series: 'kube_poddisruptionbudget_status_expected_pods{cluster="cluster1", namespace="ns1", poddisruptionbudget="pdb1", job="kube-state-metrics"}'
+    values: '0x30'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: KubePdbNotEnoughHealthyPods
+  - eval_time: 30m
+    alertname: KubePdbNotEnoughHealthyPods
 
 - interval: 1m
   name: KubeStatefulSetUpdateNotRolledOut still fires even if another label (e.g. instance) is present


### PR DESCRIPTION
#### What does this PR fix? Please be as descriptive as possible.

`KubePdbNotEnoughHealthyPods` fires indefinitely on workloads that are intentionally scaled to zero replicas.

A PodDisruptionBudget with an absolute `minAvailable` reports `desiredHealthy` straight from the spec, regardless of how many pods its selector matches. At 0 replicas it reports `desiredHealthy: 1`, `currentHealthy: 0`, `expectedPods: 0` — so the expression sees a deficit of 1 that nothing will ever resolve, and the alert can never clear.

Guarding on `expectedPods > 0` fixes it: a PDB whose selector matches no pods has no disruption budget that can be violated. Only the absolute `minAvailable` form is affected — `maxUnavailable` and percentage `minAvailable` already derive `desiredHealthy` from `expectedPods`. Pods missing *unexpectedly* stay covered by `Kube*ReplicasMismatch`.

The existing test case had no `expected_pods` series, so it gains one. A new case covers the zero-replica scenario and fails without this change.

#### Any helpful code snippets or visual aids (before and after this patch, if applicable)?
<details>
<summary>Details</summary>

PDB status for a Deployment parked at 0 replicas — the state that alerts forever today:

```yaml
status:
  expectedPods:       0
  currentHealthy:     0
  desiredHealthy:     1   # from spec.minAvailable, not derived from expectedPods
  disruptionsAllowed: 0
```

Expression after this patch:

```
(
  kube_poddisruptionbudget_status_desired_healthy{...}
  -
  kube_poddisruptionbudget_status_current_healthy{...}
)
> 0
and
kube_poddisruptionbudget_status_expected_pods{...}
> 0
```

</details>