### PR TITLE
Exclude streaming subresources from apiserver error-rate calculation

### DIFF
--- a/rules/kube_apiserver-availability.libsonnet
+++ b/rules/kube_apiserver-availability.libsonnet
@@ -161,8 +161,8 @@
           {
             record: 'code_verb:apiserver_request_total:increase1h',
             expr: |||
-              sum by (%s, code, verb) (increase(apiserver_request_total{%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
-            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, code],
+              sum by (%s, code, verb) (increase(apiserver_request_total{%s,%s,verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"%s"}[1h]))
+            ||| % [$._config.clusterLabel, $._config.kubeApiserverSelector, $._config.kubeApiserverNonStreamingSelector, code],
           }
           for code in ['2..', '3..', '4..', '5..']
         ],

--- a/rules/kube_apiserver-burnrate.libsonnet
+++ b/rules/kube_apiserver-burnrate.libsonnet
@@ -41,10 +41,10 @@
                 )
                 +
                 # errors
-                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,code=~"5.."}[%(window)s]))
+                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,code=~"5.."}[%(window)s]))
               )
               /
-              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(window)s]))
+              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
             ||| % {
               clusterLabel: $._config.clusterLabel,
               window: w,
@@ -78,10 +78,10 @@
                   sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s,le=~"%(kubeApiserverWriteLatency)s"}[%(window)s]))
                 )
                 +
-                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,code=~"5.."}[%(window)s]))
+                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s,code=~"5.."}[%(window)s]))
               )
               /
-              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s}[%(window)s]))
+              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
             ||| % {
               clusterLabel: $._config.clusterLabel,
               window: w,

--- a/tests/apiserver-availability-test.yaml
+++ b/tests/apiserver-availability-test.yaml
@@ -54,3 +54,26 @@ tests:
       value: 3.96e+4 # average of the input series values times 24 (hours) times 30 (days)
     - labels: 'code_verb:apiserver_request_total:increase30d{code="500", verb="GET"}'
       value: 3.24e+3
+
+- name: proxy subresource errors do not count towards apiserver request total increase 1h
+  interval: 1m
+  input_series:
+  # 99 successful non-proxy GETs, 1 non-proxy 5xx (genuine apiserver error)
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="GET",code="200"}'
+    values: '0 10 20 50 90 99'
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="GET",code="500"}'
+    values: '0x2 1x2'
+  # a much larger stream of services/proxy 5xx (e.g. a proxied Service with
+  # no ready endpoints) must not inflate the apiserver error count
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="GET",resource="services",subresource="proxy",code="503"}'
+    values: '0 200 400 700 900 1000'
+
+  promql_expr_test:
+  - eval_time: 5m
+    expr: code_verb:apiserver_request_total:increase1h{verb="GET"}
+    exp_samples:
+    - labels: 'code_verb:apiserver_request_total:increase1h{code="200", verb="GET"}'
+      value: 99.0
+    - labels: 'code_verb:apiserver_request_total:increase1h{code="500", verb="GET"}'
+      value: 1.0
+      # note: no {code="503", verb="GET"} sample -- the 1000 proxy 503s are excluded


### PR DESCRIPTION
Fixes #1273 (to fill in after the issue above is filed).

## What this does

`kubeApiserverNonStreamingSelector` (`subresource!~"proxy|attach|log|exec|portforward"`)
was added in #740 and is applied to the **latency** term of the apiserver
burnrate rules. This PR applies the same selector to the **errors** term of
both burnrate rules, and to `code_verb:apiserver_request_total:increase1h`
(the shared recording rule that every `apiserver_request:availability*`
series derives from), so streaming/passthrough subresources (`proxy`,
`attach`, `log`, `exec`, `portforward`) are excluded consistently from both
latency and error accounting -- not just latency.

## Why

A 5xx from `services/proxy`, `pods/exec`, `pods/log`, etc. reflects the
proxied target's health, not the apiserver control plane's -- apiserver is
behaving correctly by forwarding the target's status code
(`ResolveEndpoint()` returns 503 by design when a proxied Service has no
ready endpoint). Left unfiltered, a single misbehaving proxied target can
dominate the write/read availability burn-rate and error-budget
calculations. See the linked issue for production numbers (2.9% -> 0% error
ratio on the same window once proxy traffic is excluded) and the prior-art
history (#671, kubernetes/community#6050, #720, #722).

## Diff

- `rules/kube_apiserver-burnrate.libsonnet` -- add `kubeApiserverNonStreamingSelector`
  to the errors term (numerator and denominator) of both the read and write
  burnrate rules
- `rules/kube_apiserver-availability.libsonnet` -- add
  `kubeApiserverNonStreamingSelector` to `code_verb:apiserver_request_total:increase1h`
  (verified this recording rule has no other consumers in the repo, so the
  change only affects the availability calculation chain)
- `tests/apiserver-availability-test.yaml` -- new test: a large stream of
  `services/proxy` 503s must not appear in
  `code_verb:apiserver_request_total:increase1h`

## Testing

```
make generate   # jsonnetfmt + jsonnet-lint clean
make test       # promtool test rules tests/*.yaml -- all suites pass
```

Confirmed the new test fails without this change (the `services/proxy` 503s
leak into a spurious `code="503"` sample) and passes with it. Diffed
`prometheus_rules.yaml` before/after to confirm the only changes are the
intended `subresource!~"proxy|attach|log|exec|portforward"` additions across
the burnrate windows and the four `code_verb:apiserver_request_total:increase1h`
code buckets -- no unrelated rules changed.

## Out of scope

- `code_resource:apiserver_request_total:rate5m` (diagnostic, resource-level
  rate used for dashboards, not part of the availability SLO calculation) is
  intentionally left unfiltered -- it's meant to show raw per-resource
  traffic including proxy calls for troubleshooting.
- Port-forward-specific handling per #652 is out of scope, same as #722.
