### PR TITLE
workload type normalization (rel #1247)

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -501,6 +501,50 @@
               |||
             ) % $._config
           },
+        ] + [
+          {
+            record: 'namespace_workload:kube_pods_desired:sum',
+            expr: (
+              |||
+                sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                 label_replace(label_replace(%(workloadMetric)s,
+                     "workload", "$1", "%(workloadLabel)s", "(.+)"),
+                   "workload_type", "%(workloadType)s", "", "")
+                  * on (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) group_left ()
+                  namespace_workload:kube_workload:relabel
+                )
+              |||
+            ) % ($._config + metricTuple),
+            labels: {
+              workload_type: metricTuple.workloadType
+            },
+          } for metricTuple in [
+            {
+              workloadMetric: "kube_daemonset_status_desired_number_scheduled",
+              workloadLabel: "daemonset",
+              workloadType: workloadTypes.daemonSet,
+            },
+            {
+              workloadMetric: "kube_deployment_spec_replicas",
+              workloadLabel: "deployment",
+              workloadType: workloadTypes.deployment,
+            },
+            {
+              workloadMetric: "kube_job_spec_completions",
+              workloadLabel: "job_name",
+              workloadType: workloadTypes.job,
+            },
+            {
+              workloadMetric: "kube_replicaset_spec_replicas",
+              workloadLabel: "replicaset",
+              workloadType: workloadTypes.replicaSet,
+            },
+            {
+              workloadMetric: "kube_statefulset_replicas",
+              workloadLabel: "statefulset",
+              workloadType: workloadTypes.statefulSet,
+            },
+          ]
         ]
       },
     ],

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -388,6 +388,83 @@
           },
         ],
       },
+      {
+        name: 'k8s.rules.workload',
+        local workloadTypes = (
+           if $._config.usePascalCaseForWorkloadTypeLabelValues then
+           {
+             barePod: "BarePod",
+             daemonSet: "DaemonSet",
+             deployment: "Deployment",
+             job: "Job",
+             replicaSet: "ReplicaSet",
+             statefulSet: "StatefulSet",
+             staticPod: "StaticPod",
+           }
+           else
+           {
+             barePod: "barepod",
+             daemonSet: "daemonset",
+             deployment: "deployment",
+             job: "job",
+             replicaSet: "replicaset",
+             statefulSet: "statefulset",
+             staticPod: "staticpod",
+           }
+        ),
+        local knownManagedPodOwnerMatchers = "%(daemonSet)s|%(deployment)s|%(job)s|%(replicaSet)s|%(statefulSet)s" % workloadTypes,
+        rules: [
+          {
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+              ||| % $._config) +
+              (
+               |||
+                 label_replace(label_replace(kube_deployment_spec_replicas,
+                     "workload", "$1", "deployment", "(.+)"),
+                   "workload_type", "%(deployment)s", "", "")
+                 OR
+                 label_replace(label_replace(kube_daemonset_status_desired_number_scheduled,
+                     "workload", "$1", "daemonset", "(.+)"),
+                   "workload_type", "%(daemonSet)s", "", "")
+                 OR
+                 label_replace(label_replace(kube_statefulset_replicas,
+                     "workload", "$1", "statefulset", "(.+)"),
+                   "workload_type", "%(statefulSet)s", "", "")
+                 OR
+                 label_replace(label_replace(kube_job_owner{owner_name=""},
+                     "workload", "$1", "job_name", "(.+)"),
+                   "workload_type", "%(job)s", "", "")
+                 OR
+                 label_replace(label_replace(
+                     kube_replicaset_spec_replicas
+                       * on (%(clusterLabel)s, %(namespaceLabel)s, replicaset) group_left ()
+                       kube_replicaset_owner{owner_kind=""},
+                     "workload", "$1", "replicaset", "(.+)"),
+                   "workload_type", "%(replicaSet)s", "", "")
+               ||| % (workloadTypes + {
+                 clusterLabel: $._config.clusterLabel,
+                 namespaceLabel: $._config.namespaceLabel,
+               })
+               ) +
+               (|||
+                  OR
+                    max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                      namespace_workload_pod:kube_pod_owner:relabel{
+                        workload_type!~"%(knownManagedPodOwnerMatchers)s"
+                      }
+                    )
+                  ) * 0) + 1
+                |||) % {
+                  knownManagedPodOwnerMatchers: knownManagedPodOwnerMatchers,
+                  clusterLabel: $._config.clusterLabel,
+                  namespaceLabel: $._config.namespaceLabel,
+                }
+          },
+        ]
+      },
     ],
   },
 }

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -431,7 +431,7 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_daemonset_status_desired_number_scheduled,
+                    label_replace(label_replace(kube_daemonset_status_desired_number_scheduled{%(kubeStateMetricsSelector)s},
                       "workload", "$1", "daemonset", "(.+)"),
                     "workload_type", "%(daemonSet)s", "", "")
                   ) * 0
@@ -446,7 +446,7 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_deployment_spec_replicas,
+                    label_replace(label_replace(kube_deployment_spec_replicas{%(kubeStateMetricsSelector)s},
                       "workload", "$1", "deployment", "(.+)"),
                     "workload_type", "%(deployment)s", "", "")
                   ) * 0
@@ -461,7 +461,7 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_job_owner{owner_kind=""},
+                    label_replace(label_replace(kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind=""},
                         "workload", "$1", "job_name", "(.+)"),
                       "workload_type", "%(job)s", "", "")
                   ) * 0
@@ -476,7 +476,7 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_job_owner{owner_kind="Pod", owner_is_controller="true"},
+                    label_replace(label_replace(kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind="Pod", owner_is_controller="true"},
                         "workload", "$1", "job_name", "(.+)"),
                       "workload_type", "%(job)s", "", "")
                   ) * 0
@@ -492,9 +492,9 @@
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
                     label_replace(label_replace(
-                        max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_spec_replicas)
+                        max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_spec_replicas{%(kubeStateMetricsSelector)s})
                           * on (%(clusterLabel)s, %(namespaceLabel)s, replicaset) group_left ()
-                          max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_owner{owner_kind=""}),
+                          max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_owner{%(kubeStateMetricsSelector)s, owner_kind=""}),
                         "workload", "$1", "replicaset", "(.+)"),
                       "workload_type", "%(replicaSet)s", "", "")
                   ) * 0
@@ -509,7 +509,7 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_statefulset_replicas,
+                    label_replace(label_replace(kube_statefulset_replicas{%(kubeStateMetricsSelector)s},
                         "workload", "$1", "statefulset", "(.+)"),
                       "workload_type", "%(statefulSet)s", "", "")
                   ) * 0
@@ -539,7 +539,7 @@
             expr: (
               |||
                 sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                  kube_pod_status_ready{condition="true"}
+                  kube_pod_status_ready{%(kubeStateMetricsSelector)s, condition="true"}
                   * on (%(clusterLabel)s, %(namespaceLabel)s, pod) group_left (workload, workload_type)
                   namespace_workload_pod:kube_pod_owner:relabel
                 )
@@ -551,7 +551,7 @@
             expr: (
               |||
                 sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type, phase) (
-                  kube_pod_status_phase
+                  kube_pod_status_phase{%(kubeStateMetricsSelector)s}
                   * on (%(clusterLabel)s, %(namespaceLabel)s, pod) group_left (workload, workload_type)
                   namespace_workload_pod:kube_pod_owner:relabel
                 )
@@ -564,7 +564,7 @@
             expr: (
               |||
                 sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                 label_replace(label_replace(%(workloadMetric)s,
+                 label_replace(label_replace(%(workloadMetric)s{%(kubeStateMetricsSelector)s},
                      "workload", "$1", "%(workloadLabel)s", "(.+)"),
                    "workload_type", "%(workloadType)s", "", "")
                   * on (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) group_left ()

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -425,57 +425,114 @@
         local knownManagedPodOwnerMatchers = "%(daemonSet)s|%(deployment)s|%(job)s|%(replicaSet)s|%(statefulSet)s" % workloadTypes,
         rules: [
           {
+            // DaemonSet
             record: 'namespace_workload:kube_workload:relabel',
             expr: (
               |||
-                (max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-              ||| % $._config) +
-              (
-               |||
-                 label_replace(label_replace(kube_deployment_spec_replicas,
-                     "workload", "$1", "deployment", "(.+)"),
-                   "workload_type", "%(deployment)s", "", "")
-                 OR
-                 label_replace(label_replace(kube_daemonset_status_desired_number_scheduled,
-                     "workload", "$1", "daemonset", "(.+)"),
-                   "workload_type", "%(daemonSet)s", "", "")
-                 OR
-                 label_replace(label_replace(kube_statefulset_replicas,
-                     "workload", "$1", "statefulset", "(.+)"),
-                   "workload_type", "%(statefulSet)s", "", "")
-                 OR
-                 label_replace(label_replace(kube_job_owner{owner_kind=""},
-                     "workload", "$1", "job_name", "(.+)"),
-                   "workload_type", "%(job)s", "", "")
-                 OR
-                 label_replace(label_replace(kube_job_owner{owner_kind="Pod", owner_is_controller="true"},
-                     "workload", "$1", "job_name", "(.+)"),
-                   "workload_type", "%(job)s", "", "")
-                 OR
-                 label_replace(label_replace(
-                     max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_spec_replicas)
-                       * on (%(clusterLabel)s, %(namespaceLabel)s, replicaset) group_left ()
-                       max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_owner{owner_kind=""}),
-                     "workload", "$1", "replicaset", "(.+)"),
-                   "workload_type", "%(replicaSet)s", "", "")
-               ||| % (workloadTypes + {
-                 clusterLabel: $._config.clusterLabel,
-                 namespaceLabel: $._config.namespaceLabel,
-               })
-               ) +
-               (|||
-                  OR
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(kube_daemonset_status_desired_number_scheduled,
+                      "workload", "$1", "daemonset", "(.+)"),
+                    "workload_type", "%(daemonSet)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // Deployment
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(kube_deployment_spec_replicas,
+                      "workload", "$1", "deployment", "(.+)"),
+                    "workload_type", "%(deployment)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // Job (Bare/StandAlone)
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(kube_job_owner{owner_kind=""},
+                        "workload", "$1", "job_name", "(.+)"),
+                      "workload_type", "%(job)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // Job (owned by Pod)
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(kube_job_owner{owner_kind="Pod", owner_is_controller="true"},
+                        "workload", "$1", "job_name", "(.+)"),
+                      "workload_type", "%(job)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // ReplicaSet (Bare/StandAlone)
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(
+                        max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_spec_replicas)
+                          * on (%(clusterLabel)s, %(namespaceLabel)s, replicaset) group_left ()
+                          max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_owner{owner_kind=""}),
+                        "workload", "$1", "replicaset", "(.+)"),
+                      "workload_type", "%(replicaSet)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // StatefulSet
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                    label_replace(label_replace(kube_statefulset_replicas,
+                        "workload", "$1", "statefulset", "(.+)"),
+                      "workload_type", "%(statefulSet)s", "", "")
+                  ) * 0
+                ) + 1
+              ||| % ($._config + workloadTypes)
+            )
+          },
+          {
+            // Fallback
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  (
                     max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
                       namespace_workload_pod:kube_pod_owner:relabel{
                         workload_type!~"%(knownManagedPodOwnerMatchers)s"
                       }
-                    )
-                  ) * 0) + 1
-                |||) % {
-                  knownManagedPodOwnerMatchers: knownManagedPodOwnerMatchers,
-                  clusterLabel: $._config.clusterLabel,
-                  namespaceLabel: $._config.namespaceLabel,
-                }
+                    ) unless namespace_workload:kube_workload:relabel
+                  ) * 0
+                ) + 1
+              ||| % ($._config + {knownManagedPodOwnerMatchers: knownManagedPodOwnerMatchers})
+            )
           },
           {
             record: 'namespace_workload:kube_pods_ready:sum',

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -461,7 +461,12 @@
               |||
                 (
                   max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                    label_replace(label_replace(kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind=""},
+                    label_replace(label_replace(
+                        (
+                          kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind=""}
+                          OR
+                          (kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind!=""} unless on(%(clusterLabel)s, namespace, job_name) kube_job_owner{%(kubeStateMetricsSelector)s, owner_is_controller="true"})
+                        ),
                         "workload", "$1", "job_name", "(.+)"),
                       "workload_type", "%(job)s", "", "")
                   ) * 0

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -227,7 +227,7 @@
               max by (%(clusterLabel)s, namespace, workload, pod) (
                 label_replace(
                   label_replace(
-                    kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet"},
+                    kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet", owner_is_controller="true"},
                     "replicaset", "$1", "owner_name", "(.*)"
                   ) * on (%(clusterLabel)s, replicaset, namespace) group_left(owner_name) topk by(%(clusterLabel)s, replicaset, namespace) (
                     1, max by (%(clusterLabel)s, replicaset, namespace, owner_name) (
@@ -249,11 +249,11 @@
               max by (%(clusterLabel)s, namespace, workload, pod) (
                 label_replace(
                   label_replace(
-                    kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet"},
+                    kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet", owner_is_controller="true"},
                     "replicaset", "$1", "owner_name", "(.*)"
                   ) * on(replicaset, namespace, %(clusterLabel)s) group_left(owner_name) topk by(%(clusterLabel)s, replicaset, namespace) (
                     1, max by (%(clusterLabel)s, replicaset, namespace, owner_name) (
-                      kube_replicaset_owner{%(kubeStateMetricsSelector)s, owner_kind="Deployment"}
+                      kube_replicaset_owner{%(kubeStateMetricsSelector)s, owner_kind="Deployment", owner_is_controller="true"}
                     )
                   ),
                   "workload", "$1", "owner_name", "(.*)"
@@ -270,7 +270,7 @@
             expr: |||
               max by (%(clusterLabel)s, namespace, workload, pod) (
                 label_replace(
-                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="DaemonSet"},
+                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="DaemonSet", owner_is_controller="true"},
                   "workload", "$1", "owner_name", "(.*)"
                 )
               )
@@ -285,7 +285,7 @@
             expr: |||
               max by (%(clusterLabel)s, namespace, workload, pod) (
                 label_replace(
-                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="StatefulSet"},
+                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="StatefulSet", owner_is_controller="true"},
                 "workload", "$1", "owner_name", "(.*)")
               )
             ||| % $._config,
@@ -301,12 +301,22 @@
                 label_join(
                   group by (%(clusterLabel)s, namespace, job_name, pod, owner_name) (
                     label_join(
-                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Job"}
+                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Job", owner_is_controller="true"}
                     , "job_name", "", "owner_name")
                   )
                   * on (%(clusterLabel)s, namespace, job_name) group_left()
-                  group by (%(clusterLabel)s, namespace, job_name) (
-                    kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind=~"Pod|"}
+                  (
+                    group by (%(clusterLabel)s, namespace, job_name) (
+                      kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind="Pod", owner_is_controller="true"}
+                    )
+                    OR
+                    group by (%(clusterLabel)s, namespace, job_name) (
+                      kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind="", owner_is_controller=""}
+                    )
+                    OR
+                    group by (%(clusterLabel)s, namespace, job_name) (
+                      kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind!=""} unless on(%(clusterLabel)s, namespace, job_name) kube_job_owner{%(kubeStateMetricsSelector)s, owner_is_controller="true"}
+                    )
                   )
                 , "workload", "", "owner_name")
               )
@@ -335,7 +345,7 @@
             expr: |||
               max by (%(clusterLabel)s, namespace, workload, pod) (
                 label_replace(
-                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Node"},
+                  kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Node", owner_is_controller="true"},
                 "workload", "$1", "pod", "(.+)")
               )
             ||| % $._config,
@@ -352,12 +362,12 @@
                   label_join(
                     group by (%(clusterLabel)s, namespace, job_name, pod) (
                       label_join(
-                        kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Job"}
+                        kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="Job", owner_is_controller="true"}
                       , "job_name", "", "owner_name")
                     )
                     * on (%(clusterLabel)s, namespace, job_name) group_left(owner_kind, owner_name)
                     group by (%(clusterLabel)s, namespace, job_name, owner_kind, owner_name) (
-                      kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind!="Pod", owner_kind!=""}
+                      kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind!="Pod", owner_kind!="", owner_is_controller="true"}
                     )
                   , "workload", "", "owner_name")
                 , "workload_type", "", "owner_kind")
@@ -367,18 +377,18 @@
                 label_replace(
                   label_replace(
                     label_replace(
-                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet"}
+                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet", owner_is_controller="true"}
                       , "replicaset", "$1", "owner_name", "(.+)"
                     )
                     * on(%(clusterLabel)s, namespace, replicaset) group_left(owner_kind, owner_name)
                     group by (%(clusterLabel)s, namespace, replicaset, owner_kind, owner_name) (
-                      kube_replicaset_owner{%(kubeStateMetricsSelector)s, owner_kind!="Deployment", owner_kind!=""}
+                      kube_replicaset_owner{%(kubeStateMetricsSelector)s, owner_kind!="Deployment", owner_kind!="", owner_is_controller="true"}
                     )
                   , "workload", "$1", "owner_name", "(.+)")
                   OR
                   label_replace(
                     group by (%(clusterLabel)s, namespace, pod, owner_name, owner_kind) (
-                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind!="ReplicaSet", owner_kind!="DaemonSet", owner_kind!="StatefulSet", owner_kind!="Job", owner_kind!="Node", owner_kind!=""}
+                      kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind!="ReplicaSet", owner_kind!="DaemonSet", owner_kind!="StatefulSet", owner_kind!="Job", owner_kind!="Node", owner_kind!="", owner_is_controller="true"}
                     )
                     , "workload", "$1", "owner_name", "(.+)"
                   )

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -463,6 +463,30 @@
                   namespaceLabel: $._config.namespaceLabel,
                 }
           },
+          {
+            record: 'namespace_workload:kube_pods_ready:sum',
+            expr: (
+              |||
+                sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                  kube_pod_status_ready{condition="true"}
+                  * on (%(clusterLabel)s, %(namespaceLabel)s, pod) group_left (workload, workload_type)
+                  namespace_workload_pod:kube_pod_owner:relabel
+                )
+              |||
+            ) % $._config
+          },
+          {
+            record: 'namespace_workload:kube_pods_phase:sum',
+            expr: (
+              |||
+                sum by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type, phase) (
+                  kube_pod_status_phase
+                  * on (%(clusterLabel)s, %(namespaceLabel)s, pod) group_left (workload, workload_type)
+                  namespace_workload_pod:kube_pod_owner:relabel
+                )
+              |||
+            ) % $._config
+          },
         ]
       },
     ],

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -453,9 +453,9 @@
                    "workload_type", "%(job)s", "", "")
                  OR
                  label_replace(label_replace(
-                     kube_replicaset_spec_replicas
+                     max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_spec_replicas)
                        * on (%(clusterLabel)s, %(namespaceLabel)s, replicaset) group_left ()
-                       kube_replicaset_owner{owner_kind=""},
+                       max by(%(clusterLabel)s, %(namespaceLabel)s, replicaset) (kube_replicaset_owner{owner_kind=""}),
                      "workload", "$1", "replicaset", "(.+)"),
                    "workload_type", "%(replicaSet)s", "", "")
                ||| % (workloadTypes + {

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -400,29 +400,34 @@
       },
       {
         name: 'k8s.rules.workload',
+        local pascalCaseWorkloadTypes = {
+          barePod: "BarePod",
+          daemonSet: "DaemonSet",
+          deployment: "Deployment",
+          job: "Job",
+          pod: "Pod",
+          replicaSet: "ReplicaSet",
+          statefulSet: "StatefulSet",
+          staticPod: "StaticPod",
+        },
+        local downcaseWorkloadTypes = {
+          barePod: "barepod",
+          daemonSet: "daemonset",
+          deployment: "deployment",
+          job: "job",
+          pod: "pod",
+          replicaSet: "replicaset",
+          statefulSet: "statefulset",
+          staticPod: "staticpod",
+        },
         local workloadTypes = (
-           if $._config.usePascalCaseForWorkloadTypeLabelValues then
-           {
-             barePod: "BarePod",
-             daemonSet: "DaemonSet",
-             deployment: "Deployment",
-             job: "Job",
-             replicaSet: "ReplicaSet",
-             statefulSet: "StatefulSet",
-             staticPod: "StaticPod",
-           }
-           else
-           {
-             barePod: "barepod",
-             daemonSet: "daemonset",
-             deployment: "deployment",
-             job: "job",
-             replicaSet: "replicaset",
-             statefulSet: "statefulset",
-             staticPod: "staticpod",
-           }
+          if $._config.usePascalCaseForWorkloadTypeLabelValues then
+            pascalCaseWorkloadTypes
+          else
+            downcaseWorkloadTypes
         ),
-        local knownManagedPodOwnerMatchers = "%(daemonSet)s|%(deployment)s|%(job)s|%(replicaSet)s|%(statefulSet)s" % workloadTypes,
+        local knownManagedPodOwnerMatchers = "%(daemonSet)s|%(deployment)s|%(job)s|%(replicaSet)s|%(statefulSet)s" % pascalCaseWorkloadTypes,
+        local knownManagedJobOwnerMatchers = "%(pod)s" % pascalCaseWorkloadTypes,
         rules: [
           {
             // DaemonSet
@@ -523,20 +528,43 @@
             )
           },
           {
-            // Fallback
+            // workload aggregation for unknown pod owner types
             record: 'namespace_workload:kube_workload:relabel',
             expr: (
               |||
                 (
                   (
                     max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
-                      namespace_workload_pod:kube_pod_owner:relabel{
-                        workload_type!~"%(knownManagedPodOwnerMatchers)s"
-                      }
-                    ) unless namespace_workload:kube_workload:relabel
+                      label_replace(
+                        label_replace(
+                          kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind!~"%(knownManagedPodOwnerMatchers)s", owner_kind!="", owner_is_controller="true"}
+                          , "workload", "$1", "owner_name", "(.+)"
+                        )
+                      , "workload_type", "$1", "owner_kind", "(.+)")
+                    )
                   ) * 0
                 ) + 1
               ||| % ($._config + {knownManagedPodOwnerMatchers: knownManagedPodOwnerMatchers})
+            )
+          },
+          {
+            // workload aggregation for unknown job owner types (note: this includes cronjobs)
+            record: 'namespace_workload:kube_workload:relabel',
+            expr: (
+              |||
+                (
+                  (
+                    max by (%(clusterLabel)s, %(namespaceLabel)s, workload, workload_type) (
+                      label_replace(
+                        label_replace(
+                          kube_job_owner{%(kubeStateMetricsSelector)s, owner_kind!~"%(knownManagedJobOwnerMatchers)s", owner_kind!="", owner_is_controller="true"}
+                          , "workload", "$1", "owner_name", "(.+)"
+                        )
+                      , "workload_type", "$1", "owner_kind", "(.+)")
+                    )
+                  ) * 0
+                ) + 1
+              ||| % ($._config + {knownManagedJobOwnerMatchers: knownManagedJobOwnerMatchers})
             )
           },
           {

--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -434,7 +434,11 @@
                      "workload", "$1", "statefulset", "(.+)"),
                    "workload_type", "%(statefulSet)s", "", "")
                  OR
-                 label_replace(label_replace(kube_job_owner{owner_name=""},
+                 label_replace(label_replace(kube_job_owner{owner_kind=""},
+                     "workload", "$1", "job_name", "(.+)"),
+                   "workload_type", "%(job)s", "", "")
+                 OR
+                 label_replace(label_replace(kube_job_owner{owner_kind="Pod", owner_is_controller="true"},
                      "workload", "$1", "job_name", "(.+)"),
                    "workload_type", "%(job)s", "", "")
                  OR

--- a/tests/rules-workload-test.yaml
+++ b/tests/rules-workload-test.yaml
@@ -54,3 +54,83 @@ tests:
       exp_samples:
       - labels: 'namespace_workload:kube_workload:relabel{cluster="test",namespace="default",workload="standalone-rs",workload_type="replicaset"}'
         value: 1
+
+  # Record desired pods for every supported workload type.
+  - interval: 1m
+    input_series:
+    - series: 'kube_daemonset_status_desired_number_scheduled{cluster="test",namespace="default",daemonset="agent",job="kube-state-metrics",instance="ksm-1"}'
+      values: '2 2'
+    - series: 'kube_deployment_spec_replicas{cluster="test",namespace="default",deployment="api",job="kube-state-metrics",instance="ksm-1"}'
+      values: '3 3'
+    - series: 'kube_job_owner{cluster="test",namespace="default",job_name="migrate",owner_kind="",owner_name="",owner_is_controller="",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_job_spec_completions{cluster="test",namespace="default",job_name="migrate",job="kube-state-metrics",instance="ksm-1"}'
+      values: '4 4'
+    - series: 'kube_replicaset_spec_replicas{cluster="test",namespace="default",replicaset="standalone-rs",job="kube-state-metrics",instance="ksm-1"}'
+      values: '5 5'
+    - series: 'kube_replicaset_owner{cluster="test",namespace="default",replicaset="standalone-rs",owner_kind="",owner_name="",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_statefulset_replicas{cluster="test",namespace="default",statefulset="database",job="kube-state-metrics",instance="ksm-1"}'
+      values: '6 6'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="agent",workload_type="daemonset"}'
+        value: 2
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="api",workload_type="deployment"}'
+        value: 3
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="migrate",workload_type="job"}'
+        value: 4
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="standalone-rs",workload_type="replicaset"}'
+        value: 5
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="database",workload_type="statefulset"}'
+        value: 6
+
+  # Do not record a Deployment-owned ReplicaSet as a standalone workload.
+  - interval: 1m
+    input_series:
+    - series: 'kube_deployment_spec_replicas{cluster="test",namespace="default",deployment="api",job="kube-state-metrics",instance="ksm-1"}'
+      values: '3 3'
+    - series: 'kube_replicaset_spec_replicas{cluster="test",namespace="default",replicaset="api-7cc77d965f",job="kube-state-metrics",instance="ksm-1"}'
+      values: '3 3'
+    - series: 'kube_replicaset_owner{cluster="test",namespace="default",replicaset="api-7cc77d965f",owner_kind="Deployment",owner_name="api",owner_is_controller="true",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="api",workload_type="deployment"}'
+        value: 3
+
+  # Keep scaled-to-zero workloads in the desired pod output.
+  - interval: 1m
+    input_series:
+    - series: 'kube_deployment_spec_replicas{cluster="test",namespace="default",deployment="disabled-api",job="kube-state-metrics",instance="ksm-1"}'
+      values: '0 0'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="disabled-api",workload_type="deployment"}'
+        value: 0
+
+  # Keep desired counts isolated for multiple workloads in one namespace.
+  - interval: 1m
+    input_series:
+    - series: 'kube_deployment_spec_replicas{cluster="test",namespace="default",deployment="api",job="kube-state-metrics",instance="ksm-1"}'
+      values: '2 2'
+    - series: 'kube_deployment_spec_replicas{cluster="test",namespace="default",deployment="worker",job="kube-state-metrics",instance="ksm-1"}'
+      values: '7 7'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="api",workload_type="deployment"}'
+        value: 2
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="worker",workload_type="deployment"}'
+        value: 7

--- a/tests/rules-workload-test.yaml
+++ b/tests/rules-workload-test.yaml
@@ -134,3 +134,43 @@ tests:
         value: 2
       - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="worker",workload_type="deployment"}'
         value: 7
+
+  # Keep a Job with only a non-controller owner as a standalone Job workload.
+  - interval: 1m
+    input_series:
+    - series: 'kube_job_owner{cluster="test",namespace="default",job_name="worker",owner_kind="Pod",owner_name="launcher",owner_is_controller="false",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_job_spec_completions{cluster="test",namespace="default",job_name="worker",job="kube-state-metrics",instance="ksm-1"}'
+      values: '3 3'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_workload:relabel
+      exp_samples:
+      - labels: 'namespace_workload:kube_workload:relabel{cluster="test",namespace="default",workload="worker",workload_type="job"}'
+        value: 1
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="worker",workload_type="job"}'
+        value: 3
+
+  # Keep a Job with a controller Pod owner as a Job workload.
+  - interval: 1m
+    input_series:
+    - series: 'kube_job_owner{cluster="test",namespace="default",job_name="worker",owner_kind="Pod",owner_name="launcher",owner_is_controller="true",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_job_spec_completions{cluster="test",namespace="default",job_name="worker",job="kube-state-metrics",instance="ksm-1"}'
+      values: '4 4'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_workload:relabel
+      exp_samples:
+      - labels: 'namespace_workload:kube_workload:relabel{cluster="test",namespace="default",workload="worker",workload_type="job"}'
+        value: 1
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_desired:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_desired:sum{cluster="test",namespace="default",workload="worker",workload_type="job"}'
+        value: 4

--- a/tests/rules-workload-test.yaml
+++ b/tests/rules-workload-test.yaml
@@ -1,0 +1,56 @@
+# Copyright kubernetes-mixin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rule_files:
+- ../prometheus_rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Prefer the controller owner when a pod has multiple owner references
+  - interval: 1m
+    input_series:
+    - series: 'kube_pod_owner{cluster="test",namespace="default",pod="agent-abc",owner_is_controller="true",owner_kind="DaemonSet",owner_name="agent",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_pod_owner{cluster="test",namespace="default",pod="agent-abc",owner_is_controller="false",owner_kind="ConfigMap",owner_name="agent-config",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_pod_status_ready{cluster="test",namespace="default",pod="agent-abc",condition="true",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_pods_ready:sum
+      exp_samples:
+      - labels: 'namespace_workload:kube_pods_ready:sum{cluster="test",namespace="default",workload="agent",workload_type="daemonset"}'
+        value: 1
+
+  # Deduplicate standalone ReplicaSet metrics from redundant KSM instances.
+  - interval: 1m
+    input_series:
+    - series: 'kube_replicaset_spec_replicas{cluster="test",namespace="default",replicaset="standalone-rs",job="kube-state-metrics",instance="ksm-1"}'
+      values: '2 2'
+    - series: 'kube_replicaset_spec_replicas{cluster="test",namespace="default",replicaset="standalone-rs",job="kube-state-metrics",instance="ksm-2"}'
+      values: '2 2'
+    - series: 'kube_replicaset_owner{cluster="test",namespace="default",replicaset="standalone-rs",owner_kind="",owner_name="",job="kube-state-metrics",instance="ksm-1"}'
+      values: '1 1'
+    - series: 'kube_replicaset_owner{cluster="test",namespace="default",replicaset="standalone-rs",owner_kind="",owner_name="",job="kube-state-metrics",instance="ksm-2"}'
+      values: '1 1'
+
+    promql_expr_test:
+    - eval_time: 1m
+      expr: namespace_workload:kube_workload:relabel
+      exp_samples:
+      - labels: 'namespace_workload:kube_workload:relabel{cluster="test",namespace="default",workload="standalone-rs",workload_type="replicaset"}'
+        value: 1


### PR DESCRIPTION
Triggered by #1247

This is a first draft for adding additional workload-based recording rules. Specifically this adds:

* `namespace_workload:kube_workload:relabel`
  * Provides a workload list (value is always 1)
  * Sets `workload` and `workload_type`
* `namespace_workload:kube_pods_ready:sum`
  * Sum of *ready* Pods per workload (`workload`, `workload_type`)
* `namespace_workload:kube_pods_phase:sum`
  * Sum of Pods per workload (`workload`, `workload_type`) per `phase`
* `namespace_workload:kube_pods_desired:sum`
  * Number of desired Pods for a workload (`workload`, `workload_type`)
  * For `Job` resources I used completions as the relevant metric rather than parallelism. One could make the argument that Job doesn't really have a matching "desired" number of Pods. Completions is the goal of a Job, whereas parallelism just states how many Pods are allowed to run in parallel while aiming to hit the completion goal.

General notes:

* I added support for the PascalCase option for these new rules, but there is a bit of an issue since this only applies to explicitly stated resource kinds. Additional kinds indirectly captured through `owner_kind` values would not respect that setting.
* We also have the kubernetes-state-metrics filter. I wonder if (maybe not part of this PR) we should draft queries to handle multiple kubernetes-state-metrics collectors running in parallel? With the knowledge of the metric structure we should be able to dedup between them.
* Some of the existing rules do not follow the existing `namespaceLabel` config setting, which could cause potential issues (although they follow the `clusterLabel` config setting). I also noticed that we do not seem to consistently use the `podLabel` setting.
* I noticed that the existing `namespace_workload_pod:kube_pod_owner:relabel` rule did not seem to differentiate between the role of the owner (`owner_is_controller`) in all cases, which can lead to many-to-many problems later on, as there are then multiple owners. In this PR I added `owner_is_controller="true"` filters to mitigate that, but this would change how the metric is exposed compared to the past. Another alternative could be to expose the `owner_is_controller` field as well or expose it as a relabelled `workload_is_controller` label.
