### PR TITLE
fix(kube-apiserver-burnrate.rules): stage long windows on 5m rates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,12 @@ clean:
 	# Remove all files and directories ignored by git.
 	git clean -Xfd .
 
+.PHONY: config-test
+config-test: $(JSONNET_BIN) $(JSONNET_VENDOR)
+	@$(JSONNET_BIN) -J vendor tests/config-test.jsonnet > /dev/null
+
 .PHONY: test
-test: $(PROMTOOL_BIN) prometheus_alerts.yaml prometheus_rules.yaml
+test: $(PROMTOOL_BIN) config-test prometheus_alerts.yaml prometheus_rules.yaml
 	@$(PROMTOOL_BIN) test rules tests/*.yaml
 
 $(BIN_DIR):

--- a/rules/kube_apiserver-burnrate.libsonnet
+++ b/rules/kube_apiserver-burnrate.libsonnet
@@ -15,92 +15,205 @@
 
 {
   prometheusRules+:: {
+    local unitSeconds = {
+      ms: 0.001,
+      s: 1,
+      m: 60,
+      h: 60 * 60,
+      d: 24 * 60 * 60,
+      w: 7 * 24 * 60 * 60,
+      y: 365 * 24 * 60 * 60,
+    },
+
+    // Prometheus duration literals: one or more <value><unit> pairs, so 5m, 500ms, 1h30m
+    // and 2w all parse. Duration expressions are out of scope, since the window is
+    // appended to the record name and an expression cannot appear there.
+    local windowSeconds(window) =
+      local chars = std.stringChars(window);
+      local last = std.length(chars) - 1;
+      local consume(state, i) =
+        if state.skip then
+          state { skip: false }
+        else
+          local char = chars[i];
+          if char >= '0' && char <= '9' then
+            state { value: state.value + char }
+          else
+            local milli = char == 'm' && i < last && chars[i + 1] == 's';
+            local unit = if milli then 'ms' else char;
+            if !std.objectHas(unitSeconds, unit) then
+              error 'unsupported duration unit %s in window %s' % [unit, window]
+            else if state.value == '' then
+              error 'duration unit %s without a value in window %s' % [unit, window]
+            else
+              {
+                seconds: state.seconds + std.parseInt(state.value) * unitSeconds[unit],
+                value: '',
+                skip: milli,
+              };
+      local parsed = std.foldl(consume, std.range(0, last), { seconds: 0, value: '', skip: false });
+      if window == '0' then
+        0
+      else if parsed.value != '' then
+        error 'duration value without a unit in window %s' % window
+      else
+        parsed.seconds,
+
+    local shorter(a, b) = if windowSeconds(b) < windowSeconds(a) then b else a,
+    local longer(a, b) = if windowSeconds(b) > windowSeconds(a) then b else a,
+
+    local shortWindows = std.set([w.short for w in $._config.SLOs.apiserver.windows]),
+    local windows = std.set(shortWindows + [w.long for w in $._config.SLOs.apiserver.windows]),
+
+    // The intermediate series are recorded on the shortest window in use, so that the
+    // burn rate for that window stays an exact rewrite rather than an approximation.
+    local baseWindow = std.foldl(shorter, windows, windows[0]),
+
+    // Short windows decide how fast an alert reacts, so they keep reading the raw series.
+    // Longer windows are averaged from the intermediate series instead: their cost is
+    // dominated by the range length, and a range that long over the raw apiserver series
+    // is what makes this group expensive. The averaged value trails the raw one by half
+    // the base window while the request rate is changing, and matches it once the rate
+    // holds steady, which is the condition the long window is there to detect.
+    local longestShortWindow = std.foldl(longer, shortWindows, shortWindows[0]),
+    local rawWindows = [w for w in windows if windowSeconds(w) <= windowSeconds(longestShortWindow)],
+    local averagedWindows = [w for w in windows if windowSeconds(w) > windowSeconds(longestShortWindow)],
+
+    local badRecord = 'cluster_verb:apiserver_request_sli_bad_events:rate%s' % baseWindow,
+    local totalRecord = 'cluster_verb:apiserver_request_sli_events:rate%s' % baseWindow,
+
+    // Requests that either breached the latency objective for their scope or returned 5xx.
+    local badExpr(verb, window) =
+      if verb == 'read' then
+        |||
+          (
+            (
+              # too slow
+              sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
+              -
+              (
+                (
+                  sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope=~"resource|",le=~"%(kubeApiserverReadResourceLatency)s"}[%(window)s]))
+                  or
+                  vector(0)
+                )
+                +
+                sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope="namespace",le=~"%(kubeApiserverReadNamespaceLatency)s"}[%(window)s]))
+                +
+                sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope="cluster",le=~"%(kubeApiserverReadClusterLatency)s"}[%(window)s]))
+              )
+            )
+            +
+            # errors
+            sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,code=~"5.."}[%(window)s]))
+          )
+        ||| % {
+          clusterLabel: $._config.clusterLabel,
+          window: window,
+          kubeApiserverSelector: $._config.kubeApiserverSelector,
+          kubeApiserverReadSelector: $._config.kubeApiserverReadSelector,
+          kubeApiserverNonStreamingSelector: $._config.kubeApiserverNonStreamingSelector,
+          kubeApiserverReadResourceLatency: $._config.kubeApiserverReadResourceLatency,
+          kubeApiserverReadNamespaceLatency: $._config.kubeApiserverReadNamespaceLatency,
+          kubeApiserverReadClusterLatency: $._config.kubeApiserverReadClusterLatency,
+        }
+      else
+        |||
+          (
+            (
+              # too slow
+              sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
+              -
+              sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s,le=~"%(kubeApiserverWriteLatency)s"}[%(window)s]))
+            )
+            +
+            # errors
+            sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,code=~"5.."}[%(window)s]))
+          )
+        ||| % {
+          clusterLabel: $._config.clusterLabel,
+          window: window,
+          kubeApiserverSelector: $._config.kubeApiserverSelector,
+          kubeApiserverWriteSelector: $._config.kubeApiserverWriteSelector,
+          kubeApiserverNonStreamingSelector: $._config.kubeApiserverNonStreamingSelector,
+          kubeApiserverWriteLatency: $._config.kubeApiserverWriteLatency,
+        },
+
+    local totalExpr(verb, window) =
+      |||
+        sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(verbSelector)s}[%(window)s]))
+      ||| % {
+        clusterLabel: $._config.clusterLabel,
+        window: window,
+        kubeApiserverSelector: $._config.kubeApiserverSelector,
+        verbSelector: if verb == 'read' then $._config.kubeApiserverReadSelector else $._config.kubeApiserverWriteSelector,
+      },
+
     groups+: [
       {
         name: 'kube-apiserver-burnrate.rules',
-        rules: [
+        // Without SLO windows there are no KubeAPIErrorBudgetBurn alerts for these rules
+        // to feed, so record nothing rather than fail on an empty window list.
+        rules: if std.length(windows) == 0 then [] else [
           {
-            record: 'apiserver_request:burnrate%(window)s' % w,
-            expr: |||
-              (
-                (
-                  # too slow
-                  sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
-                  -
-                  (
-                    (
-                      sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope=~"resource|",le=~"%(kubeApiserverReadResourceLatency)s"}[%(window)s]))
-                      or
-                      vector(0)
-                    )
-                    +
-                    sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope="namespace",le=~"%(kubeApiserverReadNamespaceLatency)s"}[%(window)s]))
-                    +
-                    sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,%(kubeApiserverNonStreamingSelector)s,scope="cluster",le=~"%(kubeApiserverReadClusterLatency)s"}[%(window)s]))
-                  )
-                )
-                +
-                # errors
-                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s,code=~"5.."}[%(window)s]))
-              )
-              /
-              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverReadSelector)s}[%(window)s]))
-            ||| % {
-              clusterLabel: $._config.clusterLabel,
-              window: w,
-              kubeApiserverSelector: $._config.kubeApiserverSelector,
-              kubeApiserverReadSelector: $._config.kubeApiserverReadSelector,
-              kubeApiserverNonStreamingSelector: $._config.kubeApiserverNonStreamingSelector,
-              kubeApiserverReadResourceLatency: $._config.kubeApiserverReadResourceLatency,
-              kubeApiserverReadNamespaceLatency: $._config.kubeApiserverReadNamespaceLatency,
-              kubeApiserverReadClusterLatency: $._config.kubeApiserverReadClusterLatency,
-            },
+            record: badRecord,
+            expr: badExpr(verb, baseWindow),
             labels: {
-              verb: 'read',
+              verb: verb,
             },
           }
-          for w in std.set([  // Get the unique array of short and long window rates
-            w.short
-            for w in $._config.SLOs.apiserver.windows
-          ] + [
-            w.long
-            for w in $._config.SLOs.apiserver.windows
-          ])
+          for verb in ['read', 'write']
         ] + [
           {
-            record: 'apiserver_request:burnrate%(window)s' % w,
-            expr: |||
-              (
-                (
-                  # too slow
-                  sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_count{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s}[%(window)s]))
-                  -
-                  sum by (%(clusterLabel)s) (rate(apiserver_request_sli_duration_seconds_bucket{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,%(kubeApiserverNonStreamingSelector)s,le=~"%(kubeApiserverWriteLatency)s"}[%(window)s]))
-                )
-                +
-                sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s,code=~"5.."}[%(window)s]))
-              )
-              /
-              sum by (%(clusterLabel)s) (rate(apiserver_request_total{%(kubeApiserverSelector)s,%(kubeApiserverWriteSelector)s}[%(window)s]))
-            ||| % {
-              clusterLabel: $._config.clusterLabel,
-              window: w,
-              kubeApiserverSelector: $._config.kubeApiserverSelector,
-              kubeApiserverWriteSelector: $._config.kubeApiserverWriteSelector,
-              kubeApiserverNonStreamingSelector: $._config.kubeApiserverNonStreamingSelector,
-              kubeApiserverWriteLatency: $._config.kubeApiserverWriteLatency,
-            },
+            record: totalRecord,
+            expr: totalExpr(verb, baseWindow),
             labels: {
-              verb: 'write',
+              verb: verb,
             },
           }
-          for w in std.set([  // Get the unique array of short and long window rates
-            w.short
-            for w in $._config.SLOs.apiserver.windows
-          ] + [
-            w.long
-            for w in $._config.SLOs.apiserver.windows
-          ])
+          for verb in ['read', 'write']
+        ] + [
+          // Both verbs at once: the intermediate series already carry the verb label.
+          {
+            record: 'apiserver_request:burnrate%s' % baseWindow,
+            expr: |||
+              %s
+              /
+              %s
+            ||| % [badRecord, totalRecord],
+          },
+        ] + [
+          {
+            record: 'apiserver_request:burnrate%(window)s' % { window: window },
+            expr: |||
+              %(bad)s
+              /
+              %(total)s
+            ||| % {
+              bad: std.rstripChars(badExpr(verb, window), '\n'),
+              total: std.rstripChars(totalExpr(verb, window), '\n'),
+            },
+            labels: {
+              verb: verb,
+            },
+          }
+          for window in rawWindows
+          if window != baseWindow
+          for verb in ['read', 'write']
+        ] + [
+          {
+            record: 'apiserver_request:burnrate%(window)s' % { window: window },
+            expr: |||
+              avg_over_time(%(bad)s[%(window)s])
+              /
+              avg_over_time(%(total)s[%(window)s])
+            ||| % {
+              bad: badRecord,
+              total: totalRecord,
+              window: window,
+            },
+          }
+          for window in averagedWindows
         ],
       },
     ],

--- a/tests/apiserver-burnrate-test.yaml
+++ b/tests/apiserver-burnrate-test.yaml
@@ -1,0 +1,131 @@
+# Copyright kubernetes-mixin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+rule_files:
+- ../prometheus_alerts.yaml
+- ../prometheus_rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+# 600 write requests per minute, of which 60 return 5xx and a further 120 are
+# served but breach the 1s objective: 180 bad events out of 600.
+- name: write burn rate on the base window
+  interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_count{job="kube-apiserver",verb="POST",subresource=""}'
+    values: '0+600x15'
+  - series: 'apiserver_request_sli_duration_seconds_bucket{job="kube-apiserver",verb="POST",subresource="",le="1.0"}'
+    values: '0+480x15'
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="POST",code="200"}'
+    values: '0+540x15'
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="POST",code="500"}'
+    values: '0+60x15'
+
+  promql_expr_test:
+  - eval_time: 10m
+    expr: cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="write"}
+    exp_samples:
+    - labels: 'cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="write"}'
+      value: 3 # (600 - 480 too slow + 60 errors) per minute = 3/s
+  - eval_time: 10m
+    expr: cluster_verb:apiserver_request_sli_events:rate5m{verb="write"}
+    exp_samples:
+    - labels: 'cluster_verb:apiserver_request_sli_events:rate5m{verb="write"}'
+      value: 10 # 600 requests per minute = 10/s
+  - eval_time: 10m
+    expr: apiserver_request:burnrate5m{verb="write"}
+    exp_samples:
+    - labels: 'apiserver_request:burnrate5m{verb="write"}'
+      value: 0.3 # 180 bad events out of 600
+
+# 600 read requests per minute, of which 60 return 5xx and a further 60 breach
+# the objective for their scope: 120 bad events out of 600.
+- name: read burn rate on the base window
+  interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_count{job="kube-apiserver",verb="GET",subresource="",scope="resource"}'
+    values: '0+360x15'
+  - series: 'apiserver_request_sli_duration_seconds_count{job="kube-apiserver",verb="GET",subresource="",scope="namespace"}'
+    values: '0+180x15'
+  - series: 'apiserver_request_sli_duration_seconds_count{job="kube-apiserver",verb="GET",subresource="",scope="cluster"}'
+    values: '0+60x15'
+  - series: 'apiserver_request_sli_duration_seconds_bucket{job="kube-apiserver",verb="GET",subresource="",scope="resource",le="1.0"}'
+    values: '0+300x15'
+  - series: 'apiserver_request_sli_duration_seconds_bucket{job="kube-apiserver",verb="GET",subresource="",scope="namespace",le="5.0"}'
+    values: '0+180x15'
+  - series: 'apiserver_request_sli_duration_seconds_bucket{job="kube-apiserver",verb="GET",subresource="",scope="cluster",le="30.0"}'
+    values: '0+60x15'
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="GET",code="200"}'
+    values: '0+540x15'
+  - series: 'apiserver_request_total{job="kube-apiserver",verb="GET",code="500"}'
+    values: '0+60x15'
+
+  promql_expr_test:
+  - eval_time: 10m
+    expr: cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="read"}
+    exp_samples:
+    - labels: 'cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="read"}'
+      value: 2 # (600 - 540 too slow + 60 errors) per minute = 2/s
+  - eval_time: 10m
+    expr: apiserver_request:burnrate5m{verb="read"}
+    exp_samples:
+    - labels: 'apiserver_request:burnrate5m{verb="read"}'
+      value: 0.2 # 120 bad events out of 600
+
+# The long windows average the intermediate series rather than reading the raw
+# series, so they have to stay request weighted: a burst of healthy traffic must
+# dilute an earlier spell of badness in proportion to the requests served, not
+# count as an equally weighted half of the window.
+- name: long window burn rate is request weighted
+  interval: 1m
+  input_series:
+  # First half: 6 bad out of 10 requests per second. Second half: 1 out of 102.
+  - series: 'cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="write"}'
+    values: '6x29 1x29'
+  - series: 'cluster_verb:apiserver_request_sli_events:rate5m{verb="write"}'
+    values: '10x29 102x29'
+
+  promql_expr_test:
+  - eval_time: 59m
+    expr: apiserver_request:burnrate1d{verb="write"}
+    exp_samples:
+    # Request weighted: mean bad 3.5/s over mean total 56/s. Averaging the two
+    # per-half ratios instead would give (0.6 + 0.0098) / 2 = 0.3049, which
+    # would overstate the burn rate by almost five times.
+    - labels: 'apiserver_request:burnrate1d{verb="write"}'
+      value: 0.0625
+
+# While the request rate holds steady the averaged long window is exactly the
+# base window: the approximation only trails the raw value where the rate moves.
+- name: long window burn rate matches base window at a steady rate
+  interval: 1m
+  input_series:
+  - series: 'cluster_verb:apiserver_request_sli_bad_events:rate5m{verb="read"}'
+    values: '3x59'
+  - series: 'cluster_verb:apiserver_request_sli_events:rate5m{verb="read"}'
+    values: '10x59'
+
+  promql_expr_test:
+  - eval_time: 59m
+    expr: apiserver_request:burnrate1d{verb="read"}
+    exp_samples:
+    - labels: 'apiserver_request:burnrate1d{verb="read"}'
+      value: 0.3
+  - eval_time: 59m
+    expr: apiserver_request:burnrate3d{verb="read"}
+    exp_samples:
+    - labels: 'apiserver_request:burnrate3d{verb="read"}'
+      value: 0.3

--- a/tests/config-test.jsonnet
+++ b/tests/config-test.jsonnet
@@ -1,0 +1,63 @@
+// Copyright kubernetes-mixin Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generation-level regression tests for configurations the mixin has to keep supporting.
+// Evaluated by `make config-test`, where a failed assertion fails the build.
+
+local mixin = import '../mixin.libsonnet';
+
+local withApiserverWindows(windows) = mixin {
+  _config+:: {
+    SLOs+: {
+      apiserver+: {
+        windows: windows,
+      },
+    },
+  },
+};
+
+local groupRules(groups, name) =
+  local matching = [group.rules for group in groups if group.name == name];
+  if std.length(matching) == 0 then error 'no group named %s' % name else matching[0];
+
+local recordNames(rules) = std.set([rule.record for rule in rules]);
+
+local averagedRecords(rules) = std.set([
+  rule.record
+  for rule in rules
+  if std.length(std.findSubstr('avg_over_time', rule.expr)) > 0
+]);
+
+// An empty window list disables the apiserver SLOs. It has to keep emitting no burn rate
+// rules and no alerts, rather than failing generation on the empty list.
+local noWindows = withApiserverWindows([]);
+assert groupRules(noWindows.prometheusRules.groups, 'kube-apiserver-burnrate.rules') == [];
+assert groupRules(noWindows.prometheusAlerts.groups, 'kube-apiserver-slos') == [];
+
+// Windows are ordered by duration, so every Prometheus duration literal has to parse:
+// sub-second units, units coarser than a day, and compound values.
+local exoticWindows = withApiserverWindows([
+  { severity: 'critical', 'for': '2m', long: '1m30s', short: '500ms', factor: 14.4 },
+  { severity: 'warning', 'for': '3h', long: '2w', short: '1d12h', factor: 1 },
+]);
+local exoticRules = groupRules(exoticWindows.prometheusRules.groups, 'kube-apiserver-burnrate.rules');
+
+// The shortest window carries the intermediate series, and only windows longer than the
+// longest short window are averaged from them.
+assert std.member(recordNames(exoticRules), 'cluster_verb:apiserver_request_sli_bad_events:rate500ms');
+assert std.member(recordNames(exoticRules), 'cluster_verb:apiserver_request_sli_events:rate500ms');
+assert averagedRecords(exoticRules) == std.set(['apiserver_request:burnrate2w']);
+
+true


### PR DESCRIPTION
Closes #1264.

## Why

`kube-apiserver-burnrate.rules` re-reads the raw apiserver series over every window up to `3d` on every evaluation. Re-scanning thousands of histogram bucket series across multi-day ranges every 30s costs real CPU wherever it runs, including when the blocks are local. It gets far worse when the raw data is not local: a remote ruler, a short local retention with the rest behind object storage, or a memcached and S3 backed store turns each of those ranges into a distributed read, once per evaluation interval, per replica.

The reporter in #1264 sees ~22s per evaluation against a 30s interval and roughly 80% of their total rule-eval CPU. On the cluster I looked at (sharded Prometheus, so the group runs on Thanos Ruler, with 8h of local retention on receive) it was 5-12s per evaluation with a 7d peak of 18.7s: a duty cycle of 0.266 against 0.845 summed over every group in the ruler, so about a third of all rule evaluation work, to produce 21 series. The `1d` and `3d` rules are the whole of it.

## What this changes

Record `apiserver_request:bad:rate5m` and `apiserver_request:total:rate5m` once per verb, then average those over the long windows instead of re-reading the raw series:

```
apiserver_request:burnrate1d = avg_over_time(apiserver_request:bad:rate5m[1d])
                             / avg_over_time(apiserver_request:total:rate5m[1d])
```

`burnrate5m` becomes the exact ratio of the two intermediates, not an approximation. The base window is derived as the shortest window in `SLOs.apiserver.windows`, and the set to average is derived as everything longer than the longest window that appears there as a `short` window. With the default config that is `1d` and `3d`; nothing is hardcoded, so a changed window set stays consistent.

This is the same idea as #537, which replaced a raw `30d` range in `kube-apiserver-availability.rules` with an intermediate `increase1h` rule averaged over `30d`.

## Why only the long windows

#537 is precedent for the pattern but not a blank cheque for it. beorn7's justification there was explicitly that the expensive query "is for a single dashboard and not even for the alerts" (#411). These rules are the opposite case: their only consumer is `KubeAPIErrorBudgetBurn`.

So the scope is deliberately narrower than #1264 proposes. Each alert pairs a short window with a long one and needs both to fire; the short window is what decides how fast the pair reacts, and it stays a bit-exact read of the raw series. The long window is the sustained-condition half, guarded by `for:` between `2m` and `3h`, where a small lag does not matter.

Cost does not argue for going wider. Measured on the generated rules with the default config, raw data loaded per evaluation of the group:

| | rules | raw range selectors | raw range-seconds per eval |
|---|---|---|---|
| master | 14 | 70 | 3,801,000 |
| this PR | 15 | 50 | 345,000 |

90.9% less, 11x. `1d` and `3d` alone are 91% of the group's total range length, so averaging the remaining five windows would buy about 9% in exchange for making every alert's fast half approximate.

On my setup memcache usage (utilized by thanos-store) dramatically changed: from `125-180 MiB` - before fix -> to `9-20 MiB` after fix was applied.

## Accuracy

`avg_over_time` of a trailing rate is the mean rate over a window shifted back by half the base window. Concretely:

- Steady request rate: identical to the raw value.
- Changing request rate: trails the raw value by 2.5 minutes, on a window whose alert waits between 1h and 3h. This is the same "fade out at the beginning and end of the range" beorn7 described in #411.
- The ratio stays request weighted, because numerator and denominator are shifted by the same amount.

As with #537, the intermediate series must span the window before the long rules read correctly, so `burnrate1d` and `burnrate3d` need 1d and 3d of history after a fresh deploy or a data wipe. That is a much shorter ramp than the 30d #537 accepted.

## Tests

`tests/apiserver-burnrate-test.yaml` is new; the group had no test coverage at all.

- Intermediate rates and `burnrate5m` for `write`, and for `read` so the three scope branches and the `or vector(0)` fallback are exercised.
- A long window at a steady rate, which must equal the base window exactly.
- A long window that stays request weighted, which is the property #1264 could not verify because their cluster's burn rate sat at zero throughout: 6 bad out of 10 requests per second over the first half of the window, 1 out of 102 over the second. Request weighted gives 0.0625; averaging the two per-half ratios would give 0.3049, so the test fails loudly if the numerator and denominator ever stop being averaged independently.

All existing test files still pass.

## Notes for review

- **No metric is renamed.** All seven `apiserver_request:burnrate*` records keep their names and their `{cluster, verb}` label sets; the two intermediates are additions. `burnrate5m`, `burnrate1d` and `burnrate3d` no longer set `verb` explicitly and inherit it from the operands, so `sum by (cluster) (...)` in `KubeAPIErrorBudgetBurn` is unaffected. The tests assert the inherited label directly.
- **Rule order inside the group is load-bearing:** the intermediates are emitted first, so `burnrate5m` sees them in the same evaluation cycle. Worth knowing that `.pint.hcl` disables `rule/dependency`, so CI will not catch it if that order is ever broken. The test will.

