### PR TITLE
docs: update kubernetes-monitoring to kubernetes-sigs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yaml
+++ b/.github/ISSUE_TEMPLATE/bugs.yaml
@@ -21,7 +21,7 @@ body:
     - type: markdown
       attributes:
         value: |
-              Please use this template while reporting a bug and provide as much information as possible. If the matter is security related, please disclose it privately, see the project [security policy](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/SECURITY.md).
+              Please use this template while reporting a bug and provide as much information as possible. If the matter is security related, please disclose it privately, see the project [security policy](https://github.com/kubernetes-sigs/kubernetes-mixin/blob/master/SECURITY.md).
     - type: textarea
       id: cause
       attributes:

--- a/.github/ISSUE_TEMPLATE/enhancements.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancements.yaml
@@ -21,7 +21,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please use this template while proposing an enhancement and provide as much information as possible. If this is a feature request, please ensure that [a consensus has been reached](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/CONTRIBUTING.md?plain=1#L24) before submitting.
+        Please use this template while proposing an enhancement and provide as much information as possible. If this is a feature request, please ensure that [a consensus has been reached](https://github.com/kubernetes-sigs/kubernetes-mixin/blob/master/CONTRIBUTING.md?plain=1#L24) before submitting.
   - type: textarea
     id: idea
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE/prs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/prs.md
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
 <!--  Thank you for sending a pull request! We highly appreciate contributions. Here are some tips for you:
-1. If this is your first time, read our contributor guidelines: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/CONTRIBUTING.md
+1. If this is your first time, read our contributor guidelines: https://github.com/kubernetes-sigs/kubernetes-mixin/blob/master/CONTRIBUTING.md
 2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
 3. If the PR is unfinished, please mark it as a draft, to prevent false pings and noisy review cycles.
 -->

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref_name }}
-          repository: kubernetes-monitoring/kubernetes-mixin
+          repository: kubernetes-sigs/kubernetes-mixin
           generate_release_notes: true
           files: kubernetes-mixin-${{ github.ref_name }}.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ Thank you for taking an interest in the project!
 
 * **Do not open up a GitHub issue if the bug is a security vulnerability**, and instead to refer to our [security policy](SECURITY.md).
 
-* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues).
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/kubernetes-sigs/kubernetes-mixin/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **`jsonnet` snippet**, if applicable, as well as an optional **visual sample** demonstrating the expected behavior that is not occurring.
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/kubernetes-sigs/kubernetes-mixin/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **`jsonnet` snippet**, if applicable, as well as an optional **visual sample** demonstrating the expected behavior that is not occurring.
 
 * Whenever possible, use the relevant bug report templates to create the issue.
 
@@ -58,7 +58,7 @@ Thank you for taking an interest in the project!
 
 ---
 
-`kubernetes-mixin` is a volunteer effort. We encourage you to pitch in and join [the team](https://github.com/kubernetes-monitoring/kubernetes-mixin/graphs/contributors)!
+`kubernetes-mixin` is a volunteer effort. We encourage you to pitch in and join [the team](https://github.com/kubernetes-sigs/kubernetes-mixin/graphs/contributors)!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ limitations under the License. -->
 
 # Prometheus Monitoring Mixin for Kubernetes
 
-[![ci](https://github.com/kubernetes-monitoring/kubernetes-mixin/actions/workflows/ci.yaml/badge.svg)](https://github.com/kubernetes-monitoring/kubernetes-mixin/actions/workflows/ci.yaml)
+[![ci](https://github.com/kubernetes-sigs/kubernetes-mixin/actions/workflows/ci.yaml/badge.svg)](https://github.com/kubernetes-sigs/kubernetes-mixin/actions/workflows/ci.yaml)
 
 A set of Grafana dashboards and Prometheus alerts for Kubernetes.
+
+This repository was transferred from [`kubernetes-monitoring/kubernetes-mixin`](https://github.com/kubernetes-monitoring/kubernetes-mixin) to [`kubernetes-sigs/kubernetes-mixin`](https://github.com/kubernetes-sigs/kubernetes-mixin). Please reference `github.com/kubernetes-sigs/kubernetes-mixin` in your mixins going forward. Existing references to `github.com/kubernetes-monitoring/kubernetes-mixin` continue to work via GitHub's transfer redirects.
 
 ## Local development
 
@@ -54,7 +56,7 @@ make dev-down
 
 ## Releases
 
-> Note: Releases up until `release-0.12` are changes in their own branches. Changelogs are included in releases starting from [version-0.13.0](https://github.com/kubernetes-monitoring/kubernetes-mixin/releases/tag/version-0.13.0).
+> Note: Releases up until `release-0.12` are changes in their own branches. Changelogs are included in releases starting from [version-0.13.0](https://github.com/kubernetes-sigs/kubernetes-mixin/releases/tag/version-0.13.0).
 
 | Release branch | Kubernetes Compatibility | Prometheus Compatibility | Kube-state-metrics Compatibility |
 |----------------|--------------------------|--------------------------|----------------------------------|
@@ -138,7 +140,7 @@ $ brew install jsonnet
 Then, grab the mixin, its dependencies, and build:
 
 ```
-$ git clone https://github.com/kubernetes-monitoring/kubernetes-mixin
+$ git clone https://github.com/kubernetes-sigs/kubernetes-mixin
 $ cd kubernetes-mixin
 $ make generate
 ```
@@ -253,7 +255,7 @@ Then, install the kubernetes-mixin:
 
 ```
 $ jb init
-$ jb install github.com/kubernetes-monitoring/kubernetes-mixin
+$ jb install github.com/kubernetes-sigs/kubernetes-mixin
 ```
 
 Generate the alerts, rules and dashboards:

--- a/lib/add-runbook-links.libsonnet
+++ b/lib/add-runbook-links.libsonnet
@@ -25,7 +25,7 @@ local lower(x) =
 
 {
   _config+:: {
-    runbookURLPattern: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-%s',
+    runbookURLPattern: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-%s',
   },
 
   prometheusAlerts+::

--- a/runbook.md
+++ b/runbook.md
@@ -23,7 +23,7 @@ It is a recommended practice that you add an annotation of "runbook" to every pr
 
 Matthew Skelton & Rob Thatcher have an excellent [run book template](https://github.com/SkeltonThatcher/run-book-template). This template will help teams to fully consider most aspects of reliably operating most interesting software systems, if only to confirm that "this section definitely does not apply here" - a valuable realization.
 
-This page collects this repositories alerts and begins the process of describing what they mean and how it might be addressed. Links from alerts to this page are added [automatically](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/lib/add-runbook-links.libsonnet).
+This page collects this repositories alerts and begins the process of describing what they mean and how it might be addressed. Links from alerts to this page are added [automatically](https://github.com/kubernetes-sigs/kubernetes-mixin/blob/master/lib/add-runbook-links.libsonnet).
 
 ### Group Name: "kubernetes-absent"
 
@@ -250,7 +250,7 @@ This page collects this repositories alerts and begins the process of describing
 ##### Alert Name: "KubeNodeEviction"
 + *Message*: `Node {{ $labels.node }} is evicting Pods due to {{ $labels.eviction_signal }}. Eviction occurs when eviction thresholds are crossed, typically caused by Pods exceeding RAM/ephemeral-storage limits.`
 + *Severity*: info
-+ *Runbook*: [Link](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeeviction)
++ *Runbook*: [Link](https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeeviction)
 
 ##### Alert Name: "KubeletPlegDurationHigh"
 + *Message*: `The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.`

--- a/scripts/generate-notice.sh
+++ b/scripts/generate-notice.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 NOTICE_FILE="${REPO_ROOT}/NOTICE"
-GITHUB_REPO="kubernetes-monitoring/kubernetes-mixin"
+GITHUB_REPO="kubernetes-sigs/kubernetes-mixin"
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   echo "⚠️  Warning: GITHUB_TOKEN not set. API calls will be rate-limited (60/hr)." >&2

--- a/tests/absent_alert-test.yaml
+++ b/tests/absent_alert-test.yaml
@@ -34,7 +34,7 @@ tests:
       exp_annotations:
         description: "KubeAPI has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
 
 - interval: 1m
   name: KubeletDown fires when kubelet target is absent but nodes exist
@@ -57,7 +57,7 @@ tests:
       exp_annotations:
         description: "Kubelet has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
 
 - interval: 1m
   name: KubeletDown does not fire when kubelet is up
@@ -101,7 +101,7 @@ tests:
       exp_annotations:
         description: "Kubelet has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
 
 - interval: 1m
   name: KubeletDown does not fire when kubelet is up (single-cluster setup)
@@ -144,7 +144,7 @@ tests:
       exp_annotations:
         description: "KubeScheduler has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown"
 
 - interval: 1m
   name: KubeControllerManagerDown fires when kube-controller-manager target is absent
@@ -163,7 +163,7 @@ tests:
       exp_annotations:
         description: "KubeControllerManager has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown"
 
 - interval: 1m
   name: KubeProxyDown fires when kube-proxy target is absent
@@ -182,7 +182,7 @@ tests:
       exp_annotations:
         description: "KubeProxy has disappeared from Prometheus target discovery."
         summary: "Target disappeared from Prometheus target discovery."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxydown"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxydown"
 
 # InstanceUnreachable alerts - fire when scrape targets exist in service discovery but are failing (up == 0)
 
@@ -204,7 +204,7 @@ tests:
       exp_annotations:
         description: "A KubeAPI instance has been unreachable for more than 15 minutes."
         summary: "KubeAPI instance is unreachable."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiinstanceunreachable"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiinstanceunreachable"
 
 - interval: 1m
   name: KubeAPIInstanceUnreachable does not fire when kube-apiserver is up
@@ -234,7 +234,7 @@ tests:
       exp_annotations:
         description: "A Kubelet instance has been unreachable for more than 15 minutes."
         summary: "Kubelet instance is unreachable."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletinstanceunreachable"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletinstanceunreachable"
 
 - interval: 1m
   name: KubeletInstanceUnreachable does not fire when kubelet is up
@@ -264,7 +264,7 @@ tests:
       exp_annotations:
         description: "A KubeScheduler instance has been unreachable for more than 15 minutes."
         summary: "KubeScheduler instance is unreachable."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerinstanceunreachable"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerinstanceunreachable"
 
 - interval: 1m
   name: KubeSchedulerInstanceUnreachable does not fire when kube-scheduler is up
@@ -294,7 +294,7 @@ tests:
       exp_annotations:
         description: "A KubeControllerManager instance has been unreachable for more than 15 minutes."
         summary: "KubeControllerManager instance is unreachable."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerinstanceunreachable"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerinstanceunreachable"
 
 - interval: 1m
   name: KubeControllerManagerInstanceUnreachable does not fire when kube-controller-manager is up
@@ -324,7 +324,7 @@ tests:
       exp_annotations:
         description: "A KubeProxy instance has been unreachable for more than 15 minutes."
         summary: "KubeProxy instance is unreachable."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxyinstanceunreachable"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeproxyinstanceunreachable"
 
 - interval: 1m
   name: KubeProxyInstanceUnreachable does not fire when kube-proxy is up

--- a/tests/apiserver-slos-test.yaml
+++ b/tests/apiserver-slos-test.yaml
@@ -42,7 +42,7 @@ tests:
         short: "5m"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
 
 # Both halves of a pair have to be over the threshold. A long window still above it while
@@ -97,7 +97,7 @@ tests:
         short: "5m"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
 
 # The same burn rate on one verb only stays under the threshold, which is what the test
@@ -136,7 +136,7 @@ tests:
         short: "6h"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
 
 # A burn severe enough to cross every threshold has to raise all four pairs, which pins
@@ -170,7 +170,7 @@ tests:
         short: "5m"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
     - exp_labels:
         cluster: "cluster1"
@@ -179,7 +179,7 @@ tests:
         short: "30m"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
     - exp_labels:
         cluster: "cluster1"
@@ -188,7 +188,7 @@ tests:
         short: "2h"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."
     - exp_labels:
         cluster: "cluster1"
@@ -197,5 +197,5 @@ tests:
         short: "6h"
       exp_annotations:
         description: "The Kube API server is burning too much error budget."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn"
         summary: "The Kube API server is burning too much error budget."

--- a/tests/apps_alerts-test.yaml
+++ b/tests/apps_alerts-test.yaml
@@ -38,7 +38,7 @@ tests:
         job: "kube-state-metrics"
       exp_annotations:
         description: "PDB ns1/pdb1 expects 1 more healthy pods. The desired number of healthy pods has not been met for at least 15m."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepdbnotenoughhealthypods"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepdbnotenoughhealthypods"
         summary: "PDB does not have enough healthy pods."
 
 - interval: 1m
@@ -66,7 +66,7 @@ tests:
         statefulset: "ss1"
       exp_annotations:
         description: "StatefulSet ns1/ss1 update has not been rolled out."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout"
         summary: "StatefulSet update has not been rolled out."
 
 - interval: 1m
@@ -92,7 +92,7 @@ tests:
         job: "kube-state-metrics"
       exp_annotations:
         description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
         summary: "HPA is running at max replicas"
 
 - interval: 1m
@@ -140,5 +140,5 @@ tests:
         job: "kube-state-metrics"
       exp_annotations:
         description: "HPA ns1/hpa1 has been running at max replicas for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
         summary: "HPA is running at max replicas"

--- a/tests/kubelet-test.yaml
+++ b/tests/kubelet-test.yaml
@@ -76,4 +76,4 @@ tests:
       exp_annotations:
         summary: "Kubelet Pod startup latency is too high."
         description: "Kubelet Pod startup 99th percentile latency is 98.01 seconds on node ip-172-0-0-1."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletpodstartuplatencyhigh"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletpodstartuplatencyhigh"

--- a/tests/resource_alerts-test.yaml
+++ b/tests/resource_alerts-test.yaml
@@ -43,7 +43,7 @@ tests:
       exp_annotations:
         description: "30% throttling of CPU in namespace default for container test-container in pod test-pod."
         summary: "Processes experience elevated CPU throttling."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
 
 - interval: 1m
   name: KubeQuotaAlmostFull fires when quota usage is above 90%
@@ -71,7 +71,7 @@ tests:
       exp_annotations:
         description: "Namespace test-ns is using 95% of its requests.cpu quota."
         summary: "Namespace quota is going to be full."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
 
 - interval: 1m
   name: KubeQuotaFullyUsed fires when quota is 100% used
@@ -99,7 +99,7 @@ tests:
       exp_annotations:
         description: "Namespace test-ns is using 100% of its requests.memory quota."
         summary: "Namespace quota is fully used."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
 
 - interval: 1m
   name: KubeQuotaExceeded fires when quota usage exceeds 100%
@@ -127,4 +127,4 @@ tests:
       exp_annotations:
         description: "Namespace test-ns is using 120% of its pods quota."
         summary: "Namespace quota has exceeded the limits."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -50,7 +50,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolume is filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes is only 1.562% free.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
 
 # Don't alert when PVC access_mode is ReadOnlyMany
 - interval: 1m
@@ -137,7 +137,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolume is filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes is only 1.294% free.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
 
 - interval: 1m
   input_series:
@@ -162,7 +162,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolume is filling up."
         description: 'Based on recent sampling, the PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes is expected to fill up within four days. Currently 1.263% is available.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
     - exp_labels:
         job: kubelet
         namespace: monitoring
@@ -172,7 +172,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolume is filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes is only 1.263% free.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup
 
 # Block volume mounts can report 0 for the kubelet_volume_stats_used_bytes metric but it shouldn't trigger the KubePersistentVolumeFillingUp alert.
 # See https://github.com/kubernetes/kubernetes/commit/b997e0e4d6ccbead435a47d6ac75b0db3d17252f for details.
@@ -249,7 +249,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolumeInodes are filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes only has 1.562% free inodes.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
 
 # Don't alert when PVC access_mode is ReadOnlyMany
 - interval: 1m
@@ -336,7 +336,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolumeInodes are filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes only has 1.294% free inodes.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
 
 - interval: 1m
   input_series:
@@ -361,7 +361,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolumeInodes are filling up."
         description: 'Based on recent sampling, the PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes is expected to run out of inodes within four days. Currently 1.263% of its inodes are free.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
     - exp_labels:
         job: kubelet
         namespace: monitoring
@@ -371,7 +371,7 @@ tests:
       exp_annotations:
         summary: "PersistentVolumeInodes are filling up."
         description: 'The PersistentVolume claimed by somepvc in Namespace monitoring on Cluster kubernetes only has 1.263% free inodes.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup
 
 # Block volume mounts can report 0 for the kubelet_volume_stats_inodes_used metric but it shouldn't trigger the KubePersistentVolumeInodesFillingUp alert.
 # See https://github.com/kubernetes/kubernetes/commit/b997e0e4d6ccbead435a47d6ac75b0db3d17252f for details.
@@ -441,7 +441,7 @@ tests:
       exp_annotations:
         summary: "Kubelet is running at capacity."
         description: "Kubelet 'node0' is running at 100% of its Pod capacity."
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
 
 - name: KubeletTooManyPods alert (multi-node with instance as node name)
   interval: 1m
@@ -472,7 +472,7 @@ tests:
       exp_annotations:
         summary: "Kubelet is running at capacity."
         description: "Kubelet 'node1' is running at 100% of its Pod capacity."
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods
 
 - interval: 1m
   input_series:
@@ -606,7 +606,7 @@ tests:
       exp_annotations:
         summary: "Kubelet Pod Lifecycle Event Generator is taking too long to relist."
         description: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of 10 seconds on node minikube.'
-        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh'
+        runbook_url: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh'
 
 - interval: 1m
   input_series:
@@ -639,7 +639,7 @@ tests:
       exp_annotations:
         summary: "Node is not ready."
         description: 'minikube has been unready for more than 15 minutes.'
-        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready'
+        runbook_url: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready'
 
 - interval: 1m
   input_series:
@@ -676,7 +676,7 @@ tests:
       exp_annotations:
         summary: "Node has as active Condition."
         description: 'minikube has active Condition MemoryPressure. This is caused by resource usage exceeding eviction thresholds.'
-        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodepressure'
+        runbook_url: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodepressure'
 
 - interval: 1m
   input_series:
@@ -701,7 +701,7 @@ tests:
       exp_annotations:
         summary: "Node readiness status is flapping."
         description: 'The readiness status of node minikube has changed 9 times in the last 15 minutes.'
-        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping'
+        runbook_url: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping'
 
 - interval: 1m
   input_series:
@@ -724,7 +724,7 @@ tests:
       exp_annotations:
         summary: "Node is evicting pods."
         description: 'Node minikube is evicting Pods due to memory.available.  Eviction occurs when eviction thresholds are crossed, typically caused by Pods exceeding RAM/ephemeral-storage limits.'
-        runbook_url: 'https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeeviction'
+        runbook_url: 'https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeeviction'
 
 # Verify that node:node_num_cpu:sum triggers no many-to-many errors.
 - interval: 1m
@@ -789,7 +789,7 @@ tests:
 
 - interval: 1m
   input_series:
-  # Failed pods must be ignored - see https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/821
+  # Failed pods must be ignored - see https://github.com/kubernetes-sigs/kubernetes-mixin/pull/821
   - series: 'kube_pod_status_phase{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",phase="Failed",pod="failed-pods-must-be-ignored",service="ksm"}'
     values: '1+0x20'
   - series: 'kube_pod_owner{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",owner_is_controller="false",owner_kind="<None>",owner_name="failed-pods-example",pod="failed-pods-must-be-ignored",service="ksm"}'
@@ -800,7 +800,7 @@ tests:
     values: '1+0x20'
   - series: 'kube_pod_owner{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",owner_is_controller="true",owner_kind="ReplicaSet",owner_name="ds-7cc77d965f",pod="pod-ds-7cc77d965f-cgsdv",service="ksm"}'
     values: '1+0x20'
-  # Pod in Running phase but Not Ready - see https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/1239
+  # Pod in Running phase but Not Ready - see https://github.com/kubernetes-sigs/kubernetes-mixin/pull/1239
   - series: 'kube_pod_status_phase{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",phase="Running",pod="pod-running-but-not-ready",service="ksm"}'
     values: '1+0x20'
   - series: 'kube_pod_status_ready{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",pod="pod-running-but-not-ready",service="ksm",condition="true"}'
@@ -809,7 +809,7 @@ tests:
     values: '1+0x20'
   - series: 'kube_pod_owner{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",owner_is_controller="false",owner_kind="Deployment",owner_name="running-but-not-ready-example",pod="pod-running-but-not-ready",service="ksm"}'
     values: '1+0x20'
-  # Pod in Succeeded phase - should be ignored - see https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/1260
+  # Pod in Succeeded phase - should be ignored - see https://github.com/kubernetes-sigs/kubernetes-mixin/issues/1260
   - series: 'kube_pod_status_phase{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",phase="Succeeded",pod="pod-succeeded-batch-job",service="ksm"}'
     values: '1+0x20'
   - series: 'kube_pod_status_ready{endpoint="https",instance="instance1",job="kube-state-metrics",cluster="kubernetes",namespace="ns1",pod="pod-succeeded-batch-job",service="ksm",condition="true"}'
@@ -848,7 +848,7 @@ tests:
       exp_annotations:
         summary: "Pod has been in a non-ready state for more than 15 minutes."
         description: "Pod ns1/pod-ds-7cc77d965f-cgsdv has been in a non-ready state for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
     - exp_labels:
         job: kube-state-metrics
         cluster: kubernetes
@@ -858,7 +858,7 @@ tests:
       exp_annotations:
         summary: "Pod has been in a non-ready state for more than 15 minutes."
         description: "Pod ns1/pod-running-but-not-ready has been in a non-ready state for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
 
 - interval: 1m
   input_series:
@@ -998,7 +998,7 @@ tests:
       exp_annotations:
         summary: "DaemonSet rollout is stuck."
         description: 'DaemonSet monitoring/node-exporter has not finished or progressed for at least 15m.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
   - eval_time: 35m
     alertname: KubeDaemonSetRolloutStuck
 # KubeDeploymentRolloutStuck
@@ -1023,7 +1023,7 @@ tests:
       exp_annotations:
         summary: 'Deployment rollout is not progressing.'
         description: 'Rollout of deployment monitoring/stuck is not progressing for longer than 15 minutes.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck
   - eval_time: 18m
     alertname: KubeDeploymentRolloutStuck
 
@@ -1055,7 +1055,7 @@ tests:
       exp_annotations:
         summary: "DaemonSet rollout is stuck."
         description: 'DaemonSet monitoring/node-exporter has not finished or progressed for at least 15m.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
   - eval_time: 34m
     alertname: KubeDaemonSetRolloutStuck
 
@@ -1087,7 +1087,7 @@ tests:
       exp_annotations:
         summary: "DaemonSet rollout is stuck."
         description: 'DaemonSet monitoring/node-exporter has not finished or progressed for at least 15m.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
   - eval_time: 34m
     alertname: KubeDaemonSetRolloutStuck
 
@@ -1119,7 +1119,7 @@ tests:
       exp_annotations:
         summary: "DaemonSet rollout is stuck."
         description: 'DaemonSet monitoring/node-exporter has not finished or progressed for at least 15m.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck
   - eval_time: 36m
     alertname: KubeDaemonSetRolloutStuck
 
@@ -1140,7 +1140,7 @@ tests:
       exp_annotations:
         summary: "Kubelet client certificate is about to expire."
         description: 'Client certificate for Kubelet on node minikube expires in 1d 0h 0m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
   - eval_time: 1m
     alertname: KubeletClientCertificateExpiration
     exp_alerts:
@@ -1153,7 +1153,7 @@ tests:
       exp_annotations:
         summary: "Kubelet client certificate is about to expire."
         description: 'Client certificate for Kubelet on node minikube expires in 23h 59m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
     - exp_labels:
         job: kubelet
         namespace: monitoring
@@ -1163,7 +1163,7 @@ tests:
       exp_annotations:
         summary: "Kubelet client certificate is about to expire."
         description: 'Client certificate for Kubelet on node minikube expires in 23h 59m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration
 
 - interval: 1m
   input_series:
@@ -1182,7 +1182,7 @@ tests:
       exp_annotations:
         summary: "Kubelet server certificate is about to expire."
         description: 'Server certificate for Kubelet on node minikube expires in 1d 0h 0m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
   - eval_time: 1m
     alertname: KubeletServerCertificateExpiration
     exp_alerts:
@@ -1195,7 +1195,7 @@ tests:
       exp_annotations:
         summary: "Kubelet server certificate is about to expire."
         description: 'Server certificate for Kubelet on node minikube expires in 23h 59m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
     - exp_labels:
         job: kubelet
         namespace: monitoring
@@ -1205,7 +1205,7 @@ tests:
       exp_annotations:
         summary: "Kubelet server certificate is about to expire."
         description: 'Server certificate for Kubelet on node minikube expires in 23h 59m 0s.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration
 
 - interval: 1m
   input_series:
@@ -1224,7 +1224,7 @@ tests:
       exp_annotations:
         summary: "Kubelet has failed to renew its client certificate."
         description: 'Kubelet on node minikube has failed to renew its client certificate (5 errors in the last 5 minutes).'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors
 
 
 - interval: 1m
@@ -1244,7 +1244,7 @@ tests:
       exp_annotations:
         summary: "Kubelet has failed to renew its server certificate."
         description: 'Kubelet on node minikube has failed to renew its server certificate (5 errors in the last 5 minutes).'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors
 
 - interval: 1m
   input_series:
@@ -1265,7 +1265,7 @@ tests:
       exp_annotations:
         summary: "Job failed to complete."
         description: "Job ns1/job-1597623120 failed to complete. Removing failed job after investigation should clear this alert."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
 
 - interval: 1m
   input_series:
@@ -1287,7 +1287,7 @@ tests:
       exp_annotations:
         summary: "Job did not complete in time"
         description: "Job ns1/job1 is taking more than 12h 0m 0s to complete."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
 
 - interval: 1m
   input_series:
@@ -1332,7 +1332,7 @@ tests:
       exp_annotations:
         summary: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
         description: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
 
 - interval: 1m
   input_series:
@@ -1354,7 +1354,7 @@ tests:
         reason: "CrashLoopBackOff"
       exp_annotations:
         description: 'Pod test/static-web (script) is in waiting state (reason: "CrashLoopBackOff").'
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
         summary: "Pod is crash looping."
   - eval_time: 20m
     alertname: KubePodCrashLooping
@@ -1399,7 +1399,7 @@ tests:
         severity: "warning"
       exp_annotations:
         description: 'Cluster has overcommitted CPU resource requests for Namespaces.'
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
         summary: "Cluster has overcommitted CPU resource requests."
 
 # When ResourceQuota has both memory and requests.memory, min value of those will be taken into account for quota calculation.
@@ -1442,7 +1442,7 @@ tests:
         severity: "warning"
       exp_annotations:
         description: 'Cluster has overcommitted memory resource requests for Namespaces.'
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
         summary: "Cluster has overcommitted memory resource requests."
 
 # Verify KubeStatefulSetReplicasMismatch fires, when no replicas could be created
@@ -1471,7 +1471,7 @@ tests:
         statefulset: "sts"
       exp_annotations:
         description: "StatefulSet test/sts has not matched the expected number of replicas for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
         summary: "StatefulSet has not matched the expected number of replicas."
 
 # Verify KubeStatefulSetReplicasMismatch fires, when replicas could be created but are not ready
@@ -1500,7 +1500,7 @@ tests:
         statefulset: "sts"
       exp_annotations:
         description: "StatefulSet test/sts has not matched the expected number of replicas for longer than 15 minutes."
-        runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
+        runbook_url: "https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
         summary: "StatefulSet has not matched the expected number of replicas."
 
 - name: KubeCPUOvercommit alert (single-node)
@@ -1524,7 +1524,7 @@ tests:
         severity: warning
       exp_annotations:
         description: Cluster has overcommitted CPU resource requests for Pods by 0.10 CPU shares and cannot tolerate node failure.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
         summary: Cluster has overcommitted CPU resource requests.
 
 - name: KubeCPUOvercommit alert (multi-node; non-HA)
@@ -1552,7 +1552,7 @@ tests:
         severity: warning
       exp_annotations:
         description: Cluster has overcommitted CPU resource requests for Pods by 0.20 CPU shares and cannot tolerate node failure.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
         summary: Cluster has overcommitted CPU resource requests.
 
 - name: KubeCPUOvercommit alert (multi-node; HA)
@@ -1584,7 +1584,7 @@ tests:
             severity: warning
           exp_annotations:
             description: Cluster has overcommitted CPU resource requests for Pods by 0.20 CPU shares and cannot tolerate node failure.
-            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
+            runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit
             summary: Cluster has overcommitted CPU resource requests.
 
 - name: KubeMemoryOvercommit alert (single-node)
@@ -1608,7 +1608,7 @@ tests:
         severity: warning
       exp_annotations:
         description: Cluster has overcommitted memory resource requests for Pods by 1G bytes and cannot tolerate node failure.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
         summary: Cluster has overcommitted memory resource requests.
 
 - name: KubeMemoryOvercommit alert (multi-node; non-HA)
@@ -1636,7 +1636,7 @@ tests:
         severity: warning
       exp_annotations:
         description: Cluster has overcommitted memory resource requests for Pods by 2G bytes and cannot tolerate node failure.
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
+        runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
         summary: Cluster has overcommitted memory resource requests.
 
 - name: KubeMemoryOvercommit alert (multi-node; HA)
@@ -1668,5 +1668,5 @@ tests:
             severity: warning
           exp_annotations:
             description: Cluster has overcommitted memory resource requests for Pods by 2G bytes and cannot tolerate node failure.
-            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
+            runbook_url: https://github.com/kubernetes-sigs/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit
             summary: Cluster has overcommitted memory resource requests.


### PR DESCRIPTION
Update README as per [KEP stable requirements](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/5905-mixins-migration#stable):

>Update the repository's README to document the transfer and recommend that users reference kubernetes-sigs/kubernetes-mixin in their mixins going forward. This is encouraged, but not doing this will never break any functionality whatsoever, as the transfer redirects will continue to work.

Update date all other references, too. Remaining (2) refs are intentional:

```shell
git grep kubernetes-monitoring
README.md:This repository was transferred from [`kubernetes-monitoring/kubernetes-mixin`](https://github.com/kubernetes-monitoring/kubernetes-mixin) to [`kubernetes-sigs/kubernetes-mixin`](https://github.com/kubernetes-sigs/kubernetes-mixin). Please reference `github.com/kubernetes-sigs/kubernetes-mixin` in your mixins going forward. Existing references to `github.com/kubernetes-monitoring/kubernetes-mixin` continue to work via GitHub's transfer redirects.
scripts/otel-collector-deployment.values.yaml:# https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-other-methods/otel-collector/
```